### PR TITLE
ENH: add vegascope entrypoint for altair renderers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ See `https://github.com/diana-hep/vegascope <https://github.com/diana-hep/vegasc
       download_url = "https://raw.githubusercontent.com/diana-hep/vegascope/master/vegascope.py",
       license = "BSD 3-clause",
       install_requires = [],
+      entry_points = {'altair.vegalite.v2.renderer': ['vegascope=vegascope:_vegalite_renderer_entry_point']},
       classifiers = [
           "Development Status :: 5 - Production/Stable",
           "Intended Audience :: Developers",

--- a/vegascope.py
+++ b/vegascope.py
@@ -6,7 +6,7 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
 # 
-# * Redistributions of source code must retain the1 above copyright notice, this
+# * Redistributions of source code must retain the above copyright notice, this
 #   list of conditions and the following disclaimer.
 # 
 # * Redistributions in binary form must reproduce the above copyright notice,
@@ -53,7 +53,7 @@ else:
     from urllib.parse import urlparse
     unicode = str
 
-__version__ = "1.0.6dev1"
+__version__ = "1.0.6"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 

--- a/vegascope.py
+++ b/vegascope.py
@@ -6,7 +6,7 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
 # 
-# * Redistributions of source code must retain the above copyright notice, this
+# * Redistributions of source code must retain the1 above copyright notice, this
 #   list of conditions and the following disclaimer.
 # 
 # * Redistributions in binary form must reproduce the above copyright notice,
@@ -53,7 +53,7 @@ else:
     from urllib.parse import urlparse
     unicode = str
 
-__version__ = "1.0.6"
+__version__ = "1.0.6dev1"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 
@@ -377,6 +377,26 @@ class TunnelCanvas(Canvas):
     def connection(self):
         return {"terminal": "ssh -L {port}:localhost:{port} {user}@{ip}".format(port=self._port, user=getpass.getuser(), ip=self.ip),
                 "browser": "http://localhost:{port}".format(port=self._port)}
+
+
+# This is the global canvas instance used by entrypoint-based renderers
+_entrypoint_renderer_canvas = None
+
+
+def _vegalite_renderer_entry_point(spec, embed_options=None):
+    global _entrypoint_renderer_canvas
+
+    if embed_options is not None:
+        import warnings
+        warnings.warn("embed_options is not yet supported & will be ignored")
+
+    if _entrypoint_renderer_canvas is None:
+        _entrypoint_renderer_canvas = LocalCanvas()
+
+    _entrypoint_renderer_canvas(spec)
+    browser = _entrypoint_renderer_canvas.connection['browser']
+    return {'text/plain': 'Rendered at {0}'.format(browser)}
+
 
 Canvas._default = {
   "$schema": "https://vega.github.io/schema/vega-lite/v2.json",


### PR DESCRIPTION
This adds the mechanism necessary for Altair to use vegascope as a renderer.

Usage from altair looks like this, and works without any changes to the released version of altair as long as vegascope is installed:

```python
In [1]: import altair as alt

In [2]: alt.renderers.enable('vegascope')
Out[2]: RendererRegistry.enable('vegascope')

In [3]: from vega_datasets import data
In [4]: cars = data.cars()
In [5]: alt.Chart(cars).mark_point().encode(
   ...:     x='Horsepower',
   ...:     y='Miles_per_Gallon',
   ...:     color='Origin',
   ...: ).interactive()
Out[5]: Rendered at http://localhost:56982
```
when the chart is evaluated, it launches a vegascope local canvas and displays the chart. Any additional chart is then displayed on the same canvas.

The one awkward thing is that the canvas never shuts itself down... I'd be curious if you have ideas on how to do that gracefully.